### PR TITLE
fix: remove unreachable private design-system submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "design-system"]
-	path = design-system
-	url = https://github.com/PrimeUpYourLife/1132-fixer-design-system.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,9 @@
 - Keep UI changes in SwiftUI and follow existing visual/component patterns.
 
 ## Design System
-- `design-system/` is a git submodule (`https://github.com/PrimeUpYourLife/1132-fixer-design-system.git`) and the source of truth for all design decisions.
-- For any design matter — colors, typography, spacing, components, icons, visual patterns — consult `design-system/` first and follow its tokens/components.
-- Do not invent new visual patterns, colors, or component styles that diverge from `design-system/`.
-- If `design-system/` lacks guidance for a needed case, ask the user before improvising rather than guessing.
-- Run `git submodule update --init --recursive` if `design-system/` appears empty.
+- Follow the existing visual/component patterns in `Sources/1132Fixer/` — do not invent new visual patterns, colors, or component styles.
+- If existing patterns lack guidance for a needed case, ask the user before improvising rather than guessing.
+- History note: a `design-system/` git submodule (PrimeUpYourLife/1132-fixer-design-system) was referenced briefly in 2026-08 and removed — the submodule repo is PRIVATE, and a private submodule inside this PUBLIC repo breaks every recursive clone. If that repo is ever made public, the submodule may be restored deliberately.
 
 ## 1132 Fixer Zoom Launch Rules
 


### PR DESCRIPTION
Program BN-1132-FAMILY-FINALIZE (Botify-Network/Botify-Network#24209), dispatched via Control from the CR10 closure. The public macOS repo's .gitmodules referenced the PRIVATE design-system repo — every recursive clone fails, contradicting the open-source claim; identical class to 1132-Fixer-Chrome#12. Scope: .gitmodules + gitlink removal + the AGENTS.md submodule pointer (replaced with existing-patterns guidance + history note). Package.swift does not consume the submodule — no build change. Rollback: revert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified project setup by removing an unavailable design-system dependency.
  * Improved compatibility for cloning and working with the public repository.

* **Documentation**
  * Updated design guidance to encourage consistency with existing visual and component patterns.
  * Clarified how to proceed when design guidance is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->